### PR TITLE
[codex] resolve Google Drive open tool issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,4 @@ coverage.html
 *.test
 internal/files/Large Document
 internal/files/auto-name.txt
-discovery-checker
+/discovery-checker

--- a/cmd/discovery-checker/generator/generator.go
+++ b/cmd/discovery-checker/generator/generator.go
@@ -12,8 +12,6 @@ import (
 	"time"
 
 	"github.com/dl-alexandre/gdrv/internal/discovery"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 const (
@@ -37,14 +35,18 @@ const (
 
 package {{ .Package }}
 
+{{ if .NeedsTime }}import "time"
+
+{{ end }}
 {{ range .Schemas }}
 {{ if .IsEnum }}
 {{ comment .Description }}
 type {{ .GoName }} string
 
 const (
+{{ $schema := . }}
 {{ range .EnumValues }}
-	{{ $.GoName }}{{ . }} {{ $.GoName }} = "{{ . }}"
+	{{ enumConstName $schema.GoName . }} {{ $schema.GoName }} = {{ printf "%q" . }}
 {{ end }}
 )
 {{ else }}
@@ -82,12 +84,6 @@ var Service = ServiceDescriptor{
 	ServicePath: "{{ .ServicePath }}",
 }
 
-{{ range .Resources }}
-{{ comment .Name }}
-type {{ .GoName }}Descriptor struct {
-	Methods map[string]MethodDescriptor
-}
-
 type MethodDescriptor struct {
 	Name       string
 	HTTPMethod string
@@ -101,6 +97,37 @@ type ParameterDescriptor struct {
 	Location string
 	Required bool
 }
+
+type ResourceDescriptor struct {
+	Name    string
+	Methods map[string]MethodDescriptor
+}
+
+var Resources = map[string]ResourceDescriptor{
+{{ range .Resources }}
+	{{ printf "%q" .Name }}: {{ .GoName }},
+{{ end }}
+}
+
+{{ range .Resources }}
+{{ comment .Description }}
+var {{ .GoName }} = ResourceDescriptor{
+	Name: {{ printf "%q" .Name }},
+	Methods: map[string]MethodDescriptor{
+{{ range .Methods }}
+		{{ printf "%q" .Name }}: {
+			Name:       {{ printf "%q" .Name }},
+			HTTPMethod: {{ printf "%q" .HTTPMethod }},
+			Path:       {{ printf "%q" .Path }},
+			Parameters: []ParameterDescriptor{
+{{ range .Parameters }}
+				{Name: {{ printf "%q" .Name }}, Type: {{ printf "%q" .Type }}, Location: {{ printf "%q" .Location }}, Required: {{ .Required }}},
+{{ end }}
+			},
+		},
+{{ end }}
+	},
+}
 {{ end }}
 `
 )
@@ -108,6 +135,7 @@ type ParameterDescriptor struct {
 // GeneratorConfig holds configuration for code generation
 type GeneratorConfig struct {
 	PackagePrefix     string
+	PackageName       string
 	OutputDir         string
 	IncludeTimestamp  bool
 	IncludeSourceInfo bool
@@ -136,7 +164,7 @@ func NewTypeGenerator(config GeneratorConfig) (*TypeGenerator, error) {
 // Generate creates Go type definitions from a discovery document
 func (g *TypeGenerator) Generate(doc *discovery.DiscoveryDocument, serviceName string) ([]byte, error) {
 	data := typeTemplateData{
-		Package:       packageName(serviceName),
+		Package:       g.packageName(serviceName),
 		GeneratedTime: time.Now().UTC().Format(time.RFC3339),
 		ServiceName:   doc.Name,
 		ServiceTitle:  doc.Title,
@@ -144,6 +172,7 @@ func (g *TypeGenerator) Generate(doc *discovery.DiscoveryDocument, serviceName s
 		DiscoveryURL:  fmt.Sprintf("https://%s.googleapis.com/$discovery/rest?version=%s", serviceName, doc.Version),
 		Schemas:       convertSchemas(doc.Schemas),
 	}
+	data.NeedsTime = schemasNeedTime(data.Schemas)
 
 	var buf bytes.Buffer
 	if err := g.tmpl.Execute(&buf, data); err != nil {
@@ -197,7 +226,7 @@ func NewDescriptorGenerator(config GeneratorConfig) (*DescriptorGenerator, error
 // Generate creates endpoint descriptors from a discovery document
 func (g *DescriptorGenerator) Generate(doc *discovery.DiscoveryDocument, serviceName string) ([]byte, error) {
 	data := descriptorTemplateData{
-		Package:       packageName(serviceName) + "descriptors",
+		Package:       g.packageName(serviceName + "descriptors"),
 		GeneratedTime: time.Now().UTC().Format(time.RFC3339),
 		ServiceName:   doc.Name,
 		ServiceTitle:  doc.Title,
@@ -238,6 +267,20 @@ func (g *DescriptorGenerator) WriteToFile(serviceName string, content []byte) er
 	return nil
 }
 
+func (g *TypeGenerator) packageName(serviceName string) string {
+	if g.config.PackageName != "" {
+		return packageName(g.config.PackageName)
+	}
+	return packageName(serviceName)
+}
+
+func (g *DescriptorGenerator) packageName(serviceName string) string {
+	if g.config.PackageName != "" {
+		return packageName(g.config.PackageName)
+	}
+	return packageName(serviceName)
+}
+
 // Template data structures
 type typeTemplateData struct {
 	Package       string
@@ -247,6 +290,7 @@ type typeTemplateData struct {
 	Version       string
 	DiscoveryURL  string
 	Schemas       []SchemaInfo
+	NeedsTime     bool
 }
 
 type descriptorTemplateData struct {
@@ -282,9 +326,10 @@ type FieldInfo struct {
 }
 
 type ResourceInfo struct {
-	Name    string
-	GoName  string
-	Methods []MethodInfo
+	Name        string
+	GoName      string
+	Description string
+	Methods     []MethodInfo
 }
 
 type MethodInfo struct {
@@ -316,10 +361,17 @@ func NewTypeMapper(schemas map[string]discovery.Schema) *TypeMapper {
 	return &TypeMapper{schemas: schemas}
 }
 
+func (m *TypeMapper) MapSchema(schema discovery.Schema) string {
+	if schema.Type == "array" && schema.Items != nil {
+		return "[]" + m.MapSchema(*schema.Items)
+	}
+	return m.MapJSONType(schema.Type, schema.Format, schema.Ref)
+}
+
 func (m *TypeMapper) MapJSONType(jsonType, format, ref string) string {
 	// Handle $ref references
 	if ref != "" {
-		return ref
+		return toGoName(ref)
 	}
 
 	// Map JSON Schema types to Go types
@@ -358,7 +410,8 @@ func (m *TypeMapper) MapJSONType(jsonType, format, ref string) string {
 // templateFuncs returns functions available in templates
 func templateFuncs() template.FuncMap {
 	return template.FuncMap{
-		"toGoName": toGoName,
+		"toGoName":      toGoName,
+		"enumConstName": enumConstName,
 		"toJSONName": func(s string) string {
 			return s
 		},
@@ -368,12 +421,68 @@ func templateFuncs() template.FuncMap {
 
 // toGoName converts a discovery name to Go naming convention
 func toGoName(name string) string {
-	// Simple conversion - production would need more logic
-	parts := strings.Split(name, "_")
-	for i, part := range parts {
-		parts[i] = cases.Title(language.English).String(part)
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "Value"
 	}
-	return strings.Join(parts, "")
+
+	var parts []string
+	var current strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			current.WriteRune(r)
+		default:
+			if current.Len() > 0 {
+				parts = append(parts, current.String())
+				current.Reset()
+			}
+		}
+	}
+	if current.Len() > 0 {
+		parts = append(parts, current.String())
+	}
+	if len(parts) == 0 {
+		return "Value"
+	}
+
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(part[:1]) + part[1:]
+	}
+
+	result := strings.Join(parts, "")
+	if result == "" {
+		return "Value"
+	}
+	if result[0] >= '0' && result[0] <= '9' {
+		result = "Value" + result
+	}
+	if isGoKeyword(strings.ToLower(result)) {
+		result += "Value"
+	}
+	return result
+}
+
+func enumConstName(typeName, value string) string {
+	name := toGoName(value)
+	if name == "Value" {
+		name = "Unknown"
+	}
+	return typeName + name
+}
+
+func isGoKeyword(name string) bool {
+	switch name {
+	case "break", "default", "func", "interface", "select", "case", "defer", "go", "map", "struct",
+		"chan", "else", "goto", "package", "switch", "const", "fallthrough", "if", "range",
+		"type", "continue", "for", "import", "return", "var":
+		return true
+	default:
+		return false
+	}
 }
 
 // formatComment formats a string as a Go comment
@@ -392,7 +501,11 @@ func formatComment(s string) string {
 
 // packageName converts service name to Go package name
 func packageName(service string) string {
-	return strings.ToLower(service)
+	name := strings.ToLower(toGoName(service))
+	if name == "" {
+		return "generated"
+	}
+	return name
 }
 
 // convertSchemas transforms discovery schemas to template-friendly format
@@ -439,7 +552,7 @@ func convertSchemas(schemas map[string]discovery.Schema) []SchemaInfo {
 			}
 
 			mapper := NewTypeMapper(schemas)
-			field.Type = mapper.MapJSONType(prop.Type, prop.Format, prop.Ref)
+			field.Type = mapper.MapSchema(prop)
 
 			info.Fields = append(info.Fields, field)
 		}
@@ -452,15 +565,35 @@ func convertSchemas(schemas map[string]discovery.Schema) []SchemaInfo {
 // convertResources transforms discovery resources to template-friendly format
 func convertResources(resources map[string]discovery.Resource) []ResourceInfo {
 	var result []ResourceInfo
-	for name, resource := range resources {
+
+	var names []string
+	for name := range resources {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		resource := resources[name]
 		info := ResourceInfo{
-			Name:   name,
-			GoName: toGoName(name),
+			Name:        name,
+			GoName:      toGoName(name),
+			Description: name,
 		}
 
-		for methodName, method := range resource.Methods {
+		var methodNames []string
+		for methodName := range resource.Methods {
+			methodNames = append(methodNames, methodName)
+		}
+		sort.Strings(methodNames)
+
+		for _, methodName := range methodNames {
+			method := resource.Methods[methodName]
+			displayName := method.ID
+			if displayName == "" {
+				displayName = methodName
+			}
 			methodInfo := MethodInfo{
-				Name:        methodName,
+				Name:        displayName,
 				GoName:      toGoName(methodName),
 				HTTPMethod:  method.HTTPMethod,
 				Path:        method.Path,
@@ -476,7 +609,14 @@ func convertResources(resources map[string]discovery.Resource) []ResourceInfo {
 			}
 
 			// Convert parameters
-			for paramName, param := range method.Parameters {
+			var paramNames []string
+			for paramName := range method.Parameters {
+				paramNames = append(paramNames, paramName)
+			}
+			sort.Strings(paramNames)
+
+			for _, paramName := range paramNames {
+				param := method.Parameters[paramName]
 				paramInfo := ParameterInfo{
 					Name:     paramName,
 					GoName:   toGoName(paramName),
@@ -493,6 +633,17 @@ func convertResources(resources map[string]discovery.Resource) []ResourceInfo {
 		result = append(result, info)
 	}
 	return result
+}
+
+func schemasNeedTime(schemas []SchemaInfo) bool {
+	for _, schema := range schemas {
+		for _, field := range schema.Fields {
+			if field.Type == "time.Time" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func contains(slice []string, item string) bool {

--- a/cmd/discovery-checker/main.go
+++ b/cmd/discovery-checker/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	discoverygen "github.com/dl-alexandre/gdrv/cmd/discovery-checker/generator"
 	"github.com/dl-alexandre/gdrv/internal/discovery"
 	"github.com/dl-alexandre/gdrv/internal/logging"
 	"gopkg.in/yaml.v3"
@@ -319,13 +320,61 @@ func saveSnapshot(path string, doc *discovery.DiscoveryDocument) error {
 }
 
 func generateTypes(doc *discovery.DiscoveryDocument, outputPath, packageName string) error {
-	// TODO: Implement Go type generation from discovery schemas
+	gen, err := discoverygen.NewTypeGenerator(discoverygen.GeneratorConfig{
+		PackageName: goPackageName(packageName, doc.Name),
+	})
+	if err != nil {
+		return err
+	}
+
+	content, err := gen.Generate(doc, doc.Name)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(outputPath, 0755); err != nil {
+		return fmt.Errorf("creating types output directory: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(outputPath, "types.go"), content, 0644); err != nil {
+		return fmt.Errorf("writing generated types: %w", err)
+	}
 	return nil
 }
 
 func generateDescriptors(doc *discovery.DiscoveryDocument, outputPath, packageName string) error {
-	// TODO: Implement endpoint descriptor generation
+	gen, err := discoverygen.NewDescriptorGenerator(discoverygen.GeneratorConfig{
+		PackageName: goPackageName(packageName, "descriptors"),
+	})
+	if err != nil {
+		return err
+	}
+
+	content, err := gen.Generate(doc, doc.Name)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
+		return fmt.Errorf("creating descriptors output directory: %w", err)
+	}
+	if err := os.WriteFile(outputPath, content, 0644); err != nil {
+		return fmt.Errorf("writing generated descriptors: %w", err)
+	}
 	return nil
+}
+
+func goPackageName(importPath, fallback string) string {
+	importPath = strings.Trim(importPath, "/")
+	if importPath == "" {
+		return fallback
+	}
+	if idx := strings.LastIndex(importPath, "/"); idx >= 0 {
+		importPath = importPath[idx+1:]
+	}
+	if importPath == "" {
+		return fallback
+	}
+	return importPath
 }
 
 // Required imports

--- a/cmd/discovery-checker/main_test.go
+++ b/cmd/discovery-checker/main_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dl-alexandre/gdrv/internal/discovery"
+)
+
+func TestGenerateTypesAndDescriptors(t *testing.T) {
+	doc := representativeDiscoveryDocument()
+	tmpDir := t.TempDir()
+
+	typesDir := filepath.Join(tmpDir, "types", "drive")
+	descPath := filepath.Join(tmpDir, "descriptors", "drive.go")
+
+	if err := generateTypes(doc, typesDir, "github.com/dl-alexandre/gdrv/internal/google/generated/drive"); err != nil {
+		t.Fatalf("generateTypes failed: %v", err)
+	}
+	if err := generateDescriptors(doc, descPath, "github.com/dl-alexandre/gdrv/internal/google/generated/descriptors"); err != nil {
+		t.Fatalf("generateDescriptors failed: %v", err)
+	}
+
+	typesPath := filepath.Join(typesDir, "types.go")
+	firstTypes := readGeneratedFile(t, typesPath)
+	firstDescriptors := readGeneratedFile(t, descPath)
+	assertParsableGo(t, typesPath, firstTypes)
+	assertParsableGo(t, descPath, firstDescriptors)
+
+	if !strings.Contains(firstTypes, "package drive") {
+		t.Fatalf("generated types used unexpected package:\n%s", firstTypes)
+	}
+	if !strings.Contains(firstTypes, `import "time"`) {
+		t.Fatalf("generated types should import time for date-time fields:\n%s", firstTypes)
+	}
+	if !strings.Contains(firstTypes, "ModifiedTime time.Time") {
+		t.Fatalf("generated types missing mapped date-time field:\n%s", firstTypes)
+	}
+	if !strings.Contains(firstTypes, `RoleOwner Role = "owner"`) {
+		t.Fatalf("generated types missing enum constant:\n%s", firstTypes)
+	}
+
+	if !strings.Contains(firstDescriptors, "package descriptors") {
+		t.Fatalf("generated descriptors used unexpected package:\n%s", firstDescriptors)
+	}
+	if !strings.Contains(firstDescriptors, "var Files = ResourceDescriptor") {
+		t.Fatalf("generated descriptors missing resource descriptor:\n%s", firstDescriptors)
+	}
+	if !strings.Contains(firstDescriptors, `"drive.files.get": {`) {
+		t.Fatalf("generated descriptors missing method descriptor:\n%s", firstDescriptors)
+	}
+	if !strings.Contains(firstDescriptors, `Name: "fileId"`) {
+		t.Fatalf("generated descriptors missing parameter descriptor:\n%s", firstDescriptors)
+	}
+
+	if err := generateTypes(doc, typesDir, "github.com/dl-alexandre/gdrv/internal/google/generated/drive"); err != nil {
+		t.Fatalf("second generateTypes failed: %v", err)
+	}
+	if err := generateDescriptors(doc, descPath, "github.com/dl-alexandre/gdrv/internal/google/generated/descriptors"); err != nil {
+		t.Fatalf("second generateDescriptors failed: %v", err)
+	}
+
+	if secondTypes := readGeneratedFile(t, typesPath); secondTypes != firstTypes {
+		t.Fatal("generated types are not stable across repeated runs")
+	}
+	if secondDescriptors := readGeneratedFile(t, descPath); secondDescriptors != firstDescriptors {
+		t.Fatal("generated descriptors are not stable across repeated runs")
+	}
+}
+
+func representativeDiscoveryDocument() *discovery.DiscoveryDocument {
+	return &discovery.DiscoveryDocument{
+		Name:        "drive",
+		Version:     "v3",
+		Title:       "Drive API",
+		BaseURL:     "https://www.googleapis.com/drive/v3/",
+		RootURL:     "https://www.googleapis.com/",
+		ServicePath: "drive/v3/",
+		Schemas: map[string]discovery.Schema{
+			"File": {
+				Type:        "object",
+				Description: "A Drive file.",
+				Required:    []string{"id"},
+				Properties: map[string]discovery.Schema{
+					"id": {
+						Type:        "string",
+						Description: "The file ID.",
+					},
+					"modifiedTime": {
+						Type:        "string",
+						Format:      "date-time",
+						Description: "The last modification time.",
+					},
+					"parents": {
+						Type:        "array",
+						Description: "Parent IDs.",
+						Items:       &discovery.Schema{Type: "string"},
+					},
+					"size": {
+						Type:   "integer",
+						Format: "int64",
+					},
+				},
+			},
+			"Role": {
+				Type:        "string",
+				Description: "Permission role.",
+				Enum:        []string{"owner", "writer"},
+			},
+		},
+		Resources: map[string]discovery.Resource{
+			"files": {
+				Methods: map[string]discovery.Method{
+					"list": {
+						ID:          "drive.files.list",
+						HTTPMethod:  "GET",
+						Path:        "files",
+						Description: "Lists files.",
+						Parameters: map[string]discovery.Parameter{
+							"pageSize": {Type: "integer", Location: "query"},
+							"fields":   {Type: "string", Location: "query"},
+						},
+					},
+					"get": {
+						ID:          "drive.files.get",
+						HTTPMethod:  "GET",
+						Path:        "files/{fileId}",
+						Description: "Gets a file.",
+						Response:    &discovery.TypeRef{Ref: "File"},
+						Parameters: map[string]discovery.Parameter{
+							"fileId": {Type: "string", Location: "path", Required: true},
+							"fields": {Type: "string", Location: "query"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func readGeneratedFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func assertParsableGo(t *testing.T, path, source string) {
+	t.Helper()
+	if _, err := parser.ParseFile(token.NewFileSet(), path, source, parser.ParseComments); err != nil {
+		t.Fatalf("generated Go does not parse for %s: %v\n%s", path, err, source)
+	}
+}

--- a/internal/auth/resolver.go
+++ b/internal/auth/resolver.go
@@ -205,10 +205,40 @@ func (r *Resolver) resolveFromCredentialsFile(ctx context.Context, filePath stri
 		return resolution, creds, nil
 
 	case formatExportBundle:
-		// TODO: Phase 3 - Load exported bundle
-		resolution.Reason = fmt.Sprintf("Export bundle format detected in %s (Phase 3 not yet implemented)", filePath)
-		return resolution, nil, utils.NewAppError(utils.NewCLIError(utils.ErrCodeAuthRequired,
-			"Export bundle support via GDRV_CREDENTIALS_FILE coming in Phase 3").Build())
+		creds, profile, err := parseExportBundleCredentials(data)
+		if err != nil {
+			resolution.Reason = fmt.Sprintf("Invalid export bundle in %s: %v", filePath, err)
+			return resolution, nil, utils.NewAppError(utils.NewCLIError(utils.ErrCodeAuthRequired,
+				fmt.Sprintf("Invalid export bundle: %v", err)).
+				WithContext("credentialsFile", filePath).
+				WithContext("suggestedAction", "export credentials again or provide a service account JSON file").
+				Build())
+		}
+
+		if !creds.ExpiryDate.IsZero() && now.After(creds.ExpiryDate) {
+			resolution.Reason = fmt.Sprintf("Export bundle token expired at %s", creds.ExpiryDate.Format(time.RFC3339))
+			return resolution, nil, utils.NewAppError(utils.NewCLIError(utils.ErrCodeAuthExpired,
+				fmt.Sprintf("Export bundle token expired at %s. Export fresh credentials or run 'gdrv auth login'.",
+					creds.ExpiryDate.Format(time.RFC3339))).
+				WithContext("credentialsFile", filePath).
+				Build())
+		}
+
+		resolution.Reason = "GDRV_CREDENTIALS_FILE export bundle"
+		resolution.Subject = profile
+		resolution.Scopes = creds.Scopes
+		resolution.Refreshable = creds.RefreshToken != "" && creds.Type == types.AuthTypeOAuth
+		if creds.ServiceAccountEmail != "" {
+			resolution.Subject = creds.ServiceAccountEmail
+		}
+		if creds.ImpersonatedUser != "" {
+			resolution.Subject = creds.ImpersonatedUser
+		}
+		if !creds.ExpiryDate.IsZero() {
+			resolution.ExpiresAt = &creds.ExpiryDate
+		}
+
+		return resolution, creds, nil
 
 	default:
 		resolution.Reason = "Unrecognized credentials file format"
@@ -330,6 +360,24 @@ const (
 	formatUnknown        fileFormat = "unknown"
 )
 
+type exportBundle struct {
+	Version       string          `json:"version"`
+	Profile       string          `json:"profile"`
+	ProfileName   string          `json:"profile_name"`
+	EncryptedData json.RawMessage `json:"encrypted_data"`
+	Salt          string          `json:"salt"`
+	Nonce         string          `json:"nonce"`
+	KeyHint       string          `json:"key_hint"`
+	Token         *exportToken    `json:"token"`
+	Credentials   json.RawMessage `json:"credentials"`
+}
+
+type exportToken struct {
+	EncryptedData string `json:"encrypted_data"`
+	Nonce         string `json:"nonce"`
+	KeyHint       string `json:"key_hint"`
+}
+
 // detectFileFormat determines the credential file type by inspecting JSON structure
 func detectFileFormat(data []byte) (fileFormat, error) {
 	// Try to parse as generic JSON first
@@ -355,7 +403,189 @@ func detectFileFormat(data []byte) (fileFormat, error) {
 		if _, hasEncrypted := generic["encrypted_data"]; hasEncrypted {
 			return formatExportBundle, nil
 		}
+		if token, ok := generic["token"].(map[string]interface{}); ok {
+			if _, hasEncrypted := token["encrypted_data"]; hasEncrypted {
+				return formatExportBundle, nil
+			}
+		}
 	}
 
 	return formatUnknown, fmt.Errorf("unrecognized format. Expected service account JSON (with type='service_account') or gdrv export bundle (with version and encrypted_data)")
+}
+
+func parseExportBundleCredentials(data []byte) (*types.Credentials, string, error) {
+	var bundle exportBundle
+	if err := json.Unmarshal(data, &bundle); err != nil {
+		return nil, "", fmt.Errorf("parse bundle JSON: %w", err)
+	}
+	if bundle.Version == "" {
+		return nil, "", fmt.Errorf("missing version")
+	}
+
+	profile := bundle.Profile
+	if profile == "" {
+		profile = bundle.ProfileName
+	}
+
+	if len(bundle.Credentials) > 0 {
+		creds, err := credentialsFromJSON(bundle.Credentials)
+		if err != nil {
+			return nil, "", fmt.Errorf("invalid credentials payload: %w", err)
+		}
+		return creds, profile, nil
+	}
+
+	if credentialsFieldPresent(data) {
+		creds, err := credentialsFromJSON(data)
+		if err != nil {
+			return nil, "", fmt.Errorf("invalid credentials payload: %w", err)
+		}
+		return creds, profile, nil
+	}
+
+	if len(bundle.EncryptedData) > 0 {
+		creds, err := credentialsFromRawBundleData(bundle.EncryptedData)
+		if err == nil {
+			return creds, profile, nil
+		}
+		if bundle.Salt != "" || bundle.Nonce != "" || bundle.KeyHint != "" {
+			return nil, "", fmt.Errorf("encrypted export bundles are not supported by this resolver: %w", err)
+		}
+		return nil, "", fmt.Errorf("invalid encrypted_data payload: %w", err)
+	}
+
+	if bundle.Token != nil && bundle.Token.EncryptedData != "" {
+		creds, err := credentialsFromEncodedBundleData(bundle.Token.EncryptedData)
+		if err == nil {
+			return creds, profile, nil
+		}
+		if bundle.Token.Nonce != "" || bundle.Token.KeyHint != "" {
+			return nil, "", fmt.Errorf("encrypted token export bundles are not supported by this resolver: %w", err)
+		}
+		return nil, "", fmt.Errorf("invalid token encrypted_data payload: %w", err)
+	}
+
+	return nil, "", fmt.Errorf("missing credentials payload")
+}
+
+func credentialsFieldPresent(data []byte) bool {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return false
+	}
+	_, ok := fields["access_token"]
+	return ok
+}
+
+func credentialsFromRawBundleData(raw json.RawMessage) (*types.Credentials, error) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return nil, fmt.Errorf("empty encrypted_data")
+	}
+	if strings.HasPrefix(trimmed, "{") {
+		return credentialsFromJSON(raw)
+	}
+
+	var encoded string
+	if err := json.Unmarshal(raw, &encoded); err != nil {
+		return nil, fmt.Errorf("encrypted_data must be a JSON object or string: %w", err)
+	}
+	return credentialsFromEncodedBundleData(encoded)
+}
+
+func credentialsFromEncodedBundleData(encoded string) (*types.Credentials, error) {
+	if strings.TrimSpace(encoded) == "" {
+		return nil, fmt.Errorf("empty encrypted_data")
+	}
+
+	if strings.HasPrefix(strings.TrimSpace(encoded), "{") {
+		return credentialsFromJSON([]byte(encoded))
+	}
+
+	decoders := []*base64.Encoding{
+		base64.StdEncoding,
+		base64.RawStdEncoding,
+		base64.URLEncoding,
+		base64.RawURLEncoding,
+	}
+
+	var lastErr error
+	for _, decoder := range decoders {
+		decoded, err := decoder.DecodeString(encoded)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		creds, err := credentialsFromJSON(decoded)
+		if err == nil {
+			return creds, nil
+		}
+		lastErr = err
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("payload is not base64 encoded JSON")
+	}
+	return nil, lastErr
+}
+
+func credentialsFromJSON(data []byte) (*types.Credentials, error) {
+	var creds types.Credentials
+	if err := json.Unmarshal(data, &creds); err == nil && creds.AccessToken != "" {
+		normalizeBundleCredentials(&creds)
+		if err := validateBundleCredentials(&creds); err != nil {
+			return nil, err
+		}
+		return &creds, nil
+	}
+
+	var stored types.StoredCredentials
+	if err := json.Unmarshal(data, &stored); err != nil {
+		return nil, err
+	}
+	if stored.AccessToken == "" {
+		return nil, fmt.Errorf("missing access_token")
+	}
+	if stored.ExpiryDate == "" {
+		return nil, fmt.Errorf("missing expiry_date")
+	}
+	expiry, err := time.Parse(time.RFC3339, stored.ExpiryDate)
+	if err != nil {
+		return nil, fmt.Errorf("invalid expiry_date: %w", err)
+	}
+
+	storedCreds := &types.Credentials{
+		AccessToken:         stored.AccessToken,
+		RefreshToken:        stored.RefreshToken,
+		ExpiryDate:          expiry,
+		Scopes:              stored.Scopes,
+		Type:                stored.Type,
+		ClientID:            stored.ClientID,
+		ServiceAccountEmail: stored.ServiceAccountEmail,
+		ImpersonatedUser:    stored.ImpersonatedUser,
+	}
+	normalizeBundleCredentials(storedCreds)
+	if err := validateBundleCredentials(storedCreds); err != nil {
+		return nil, err
+	}
+	return storedCreds, nil
+}
+
+func normalizeBundleCredentials(creds *types.Credentials) {
+	if creds.Type == "" {
+		creds.Type = types.AuthTypeOAuth
+	}
+	if len(creds.Scopes) == 0 {
+		creds.Scopes = []string{"unknown"}
+	}
+}
+
+func validateBundleCredentials(creds *types.Credentials) error {
+	if creds.AccessToken == "" {
+		return fmt.Errorf("missing access_token")
+	}
+	if creds.ExpiryDate.IsZero() {
+		return fmt.Errorf("missing expiry_date")
+	}
+	return nil
 }

--- a/internal/auth/resolver_test.go
+++ b/internal/auth/resolver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/dl-alexandre/gdrv/internal/types"
+	"github.com/dl-alexandre/gdrv/internal/utils"
 )
 
 // withEnv is a test helper that sets environment variables and restores them after the test.
@@ -539,6 +541,136 @@ func TestResolver_FileFormat_Unknown(t *testing.T) {
 	if format != formatUnknown {
 		t.Errorf("Expected unknown format, got: %s", format)
 	}
+}
+
+func TestResolver_ExportBundle_ResolvesBase64Credentials(t *testing.T) {
+	configDir := t.TempDir()
+	expiry := time.Now().Add(1 * time.Hour).UTC().Truncate(time.Second)
+	payload, err := json.Marshal(types.StoredCredentials{
+		Profile:      "work",
+		AccessToken:  "bundle-token",
+		RefreshToken: "bundle-refresh",
+		ExpiryDate:   expiry.Format(time.RFC3339),
+		Scopes:       []string{"https://www.googleapis.com/auth/drive"},
+		Type:         types.AuthTypeOAuth,
+		ClientID:     "client-123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bundle := map[string]any{
+		"version":        "1.0",
+		"profile":        "work",
+		"created_at":     "2024-01-01T00:00:00Z",
+		"encrypted_data": base64.StdEncoding.EncodeToString(payload),
+	}
+	bundleData, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpFile := createTempCredentialsFile(t, string(bundleData))
+
+	withEnv(t, map[string]string{
+		"GDRV_TOKEN":            "",
+		"GDRV_CREDENTIALS_FILE": tmpFile,
+	}, func() {
+		resolver := NewResolver(configDir, false)
+		resolution, creds, err := resolver.Resolve(context.Background(), ResolveOptions{Profile: "default"})
+		if err != nil {
+			t.Fatalf("expected export bundle to resolve, got %v", err)
+		}
+		if resolution.Source != AuthSourceCredentialsFile {
+			t.Fatalf("expected credentials file source, got %s", resolution.Source)
+		}
+		if resolution.Subject != "work" {
+			t.Fatalf("expected profile subject, got %q", resolution.Subject)
+		}
+		if !resolution.Refreshable {
+			t.Fatal("expected refreshable OAuth bundle")
+		}
+		if creds.AccessToken != "bundle-token" || creds.RefreshToken != "bundle-refresh" {
+			t.Fatalf("unexpected credentials: %+v", creds)
+		}
+		if !creds.ExpiryDate.Equal(expiry) {
+			t.Fatalf("expected expiry %s, got %s", expiry, creds.ExpiryDate)
+		}
+	})
+}
+
+func TestResolver_ExportBundle_RejectsUnsupportedEncryptedPayload(t *testing.T) {
+	configDir := t.TempDir()
+	tmpFile := createTempCredentialsFile(t, `{
+		"version": "1.0",
+		"profile": "default",
+		"encrypted_data": "not-json-ciphertext",
+		"nonce": "nonce",
+		"key_hint": "host"
+	}`)
+
+	withEnv(t, map[string]string{
+		"GDRV_TOKEN":            "",
+		"GDRV_CREDENTIALS_FILE": tmpFile,
+	}, func() {
+		resolver := NewResolver(configDir, false)
+		_, _, err := resolver.Resolve(context.Background(), ResolveOptions{})
+		if err == nil {
+			t.Fatal("expected unsupported encrypted bundle error")
+		}
+
+		var appErr *utils.AppError
+		if !errors.As(err, &appErr) {
+			t.Fatalf("expected AppError, got %T: %v", err, err)
+		}
+		if appErr.CLIError.Code != utils.ErrCodeAuthRequired {
+			t.Fatalf("expected %s, got %s", utils.ErrCodeAuthRequired, appErr.CLIError.Code)
+		}
+		if !strings.Contains(appErr.CLIError.Message, "encrypted export bundles are not supported") {
+			t.Fatalf("expected actionable encrypted bundle message, got %q", appErr.CLIError.Message)
+		}
+	})
+}
+
+func TestResolver_ExportBundle_RejectsExpiredCredentials(t *testing.T) {
+	configDir := t.TempDir()
+	payload, err := json.Marshal(types.StoredCredentials{
+		Profile:     "expired",
+		AccessToken: "expired-token",
+		ExpiryDate:  time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339),
+		Scopes:      []string{"https://www.googleapis.com/auth/drive"},
+		Type:        types.AuthTypeOAuth,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundleData, err := json.Marshal(map[string]any{
+		"version":        "1.0",
+		"profile":        "expired",
+		"encrypted_data": base64.StdEncoding.EncodeToString(payload),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpFile := createTempCredentialsFile(t, string(bundleData))
+
+	withEnv(t, map[string]string{
+		"GDRV_TOKEN":            "",
+		"GDRV_CREDENTIALS_FILE": tmpFile,
+	}, func() {
+		resolver := NewResolver(configDir, false)
+		_, _, err := resolver.Resolve(context.Background(), ResolveOptions{})
+		if err == nil {
+			t.Fatal("expected expired bundle error")
+		}
+
+		var appErr *utils.AppError
+		if !errors.As(err, &appErr) {
+			t.Fatalf("expected AppError, got %T: %v", err, err)
+		}
+		if appErr.CLIError.Code != utils.ErrCodeAuthExpired {
+			t.Fatalf("expected %s, got %s", utils.ErrCodeAuthExpired, appErr.CLIError.Code)
+		}
+	})
 }
 
 // TestResolver_JWTParsing_ScopesExtracted verifies scope extraction from JWT

--- a/internal/tui/vfs/drive.go
+++ b/internal/tui/vfs/drive.go
@@ -98,9 +98,11 @@ func (d *DriveVFS) Rename(ctx context.Context, id, name string) error {
 // Move changes a file's parent.
 func (d *DriveVFS) Move(ctx context.Context, id, newParent string) error {
 	reqCtx := d.requestContext()
-	// TODO: Need proper error handling wrapper
 	_, err := d.files.Move(ctx, reqCtx, id, newParent)
-	return err
+	if err != nil {
+		return fmt.Errorf("move file %q to parent %q: %w", id, newParent, err)
+	}
+	return nil
 }
 
 // Delete permanently removes a file.

--- a/internal/tui/vfs/drive_test.go
+++ b/internal/tui/vfs/drive_test.go
@@ -3,6 +3,7 @@ package vfs
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"github.com/dl-alexandre/gdrv/internal/files"
 	"github.com/dl-alexandre/gdrv/internal/logging"
 	gsheets "github.com/dl-alexandre/gdrv/internal/sheets"
+	"github.com/dl-alexandre/gdrv/internal/utils"
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 	sheetsapi "google.golang.org/api/sheets/v4"
@@ -127,6 +129,50 @@ func TestDriveVFSImportSheetTab_ConflictOnRevisionMismatch(t *testing.T) {
 	err := v.ImportSheetTab(context.Background(), "file123", "Sheet1", "A,B\n1,2\n", "2024-01-01T00:00:00Z")
 	if err == nil || !strings.Contains(err.Error(), "conflict:") {
 		t.Fatalf("expected conflict error, got %v", err)
+	}
+}
+
+func TestDriveVFSMove_WrapsStructuredDriveError(t *testing.T) {
+	server, driveSvc, sheetsSvc := newDriveVFSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/drive/v3/files/file123":
+			writeJSON(t, w, http.StatusOK, map[string]any{
+				"id":      "file123",
+				"name":    "Report",
+				"parents": []string{"old-parent"},
+			})
+		case r.Method == http.MethodPatch && r.URL.Path == "/drive/v3/files/file123":
+			writeJSON(t, w, http.StatusNotFound, map[string]any{
+				"error": map[string]any{
+					"code":    http.StatusNotFound,
+					"message": "File not found",
+					"errors": []map[string]any{{
+						"reason":  "notFound",
+						"message": "File not found",
+					}},
+				},
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	defer server.Close()
+
+	v := newTestDriveVFS(driveSvc, sheetsSvc, "")
+	err := v.Move(context.Background(), "file123", "new-parent")
+	if err == nil {
+		t.Fatal("expected move error")
+	}
+	if !strings.Contains(err.Error(), `move file "file123" to parent "new-parent"`) {
+		t.Fatalf("expected move context in error, got %v", err)
+	}
+
+	var appErr *utils.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected wrapped AppError, got %T: %v", err, err)
+	}
+	if appErr.CLIError.Code != utils.ErrCodeFileNotFound {
+		t.Fatalf("expected %s, got %s", utils.ErrCodeFileNotFound, appErr.CLIError.Code)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Resolve exported credential bundles through `GDRV_CREDENTIALS_FILE` with structured auth errors for malformed, expired, or unsupported encrypted payloads.
- Wire discovery-checker type and descriptor generation to the existing generator package, with deterministic output tests.
- Wrap Drive VFS move failures with operation context while preserving structured Drive errors.

Closes #76.
Closes #77.
Closes #78.

## Validation
- `go test ./...`
